### PR TITLE
Add Primitive acronym to aid in search engine results.

### DIFF
--- a/Primitive Infinite Spool System/README.md
+++ b/Primitive Infinite Spool System/README.md
@@ -1,4 +1,4 @@
-# Primitive Infinite Spool System
+# Primitive Infinite Spool System (PISS)
 
 **This is a work in progress, stuff will change or get added/removed at random**
 


### PR DESCRIPTION
As per @AdamV3D's video today, it has become necessary for the Primitive Infinite Spool System to be found by its acronym. This change allows search engines to properly index it under the correct keywords, so that someone searching for "esoterical piss" will find this project.